### PR TITLE
fix creation of new blank SourceSelector when 'removing' the last one from the GraphEdit pane

### DIFF
--- a/firefly/static/js/source_selector.js
+++ b/firefly/static/js/source_selector.js
@@ -182,5 +182,6 @@ firefly.SourceSelector.prototype._clearCurrentSrc = function() {
 
 firefly.SourceSelector.prototype._removeSourceSelector = function() {
 	this._clearCurrentSrc();
-	$(this.container).remove()
+	$(this.container).remove();
+	this.container = null;
 };


### PR DESCRIPTION
addresses #25. the code to handle the events from the "remove" button in the GraphEdit pane is split into two parts - the SourceSelector object handles removing the source from the current graph and cleaning its own container up; the GraphEdit object handles adding a new SourceSelector if there are none left.  But the GraphEdit part was totally borked and always has been.

This fixes that, renames rampant usage of 'that' (as a pointer to 'this') in the surrounding function, and patches one possible source of memory leaks, although probably not.
