### PR TITLE
Fix Scatter-Plot Data

### DIFF
--- a/firefly/data_sources/test_data.py
+++ b/firefly/data_sources/test_data.py
@@ -1,4 +1,5 @@
 import math
+import random
 
 import firefly.data_source
 
@@ -22,6 +23,7 @@ class TestData(firefly.data_source.DataSource):
         span = end - start
         data = []
         sources = self._flat_sources(sources)
+        random.seed(0)
         for x in xrange(span):
             t = x + start
             val = []
@@ -33,7 +35,7 @@ class TestData(firefly.data_source.DataSource):
                 if source == 'test-data-rough':
                     val.append(math.sin(0.5 + x*math.pi/(span/4)) + 0.15*math.sin(300*x*math.pi/span))
                 if source == 'test-data-scatter':
-                    val.append(0.53 if t%2 else None)
+                    val.append(random.random() - 0.5  if t%2 else None)
                 if source == 'test-data-discontinuous':
                     sine = math.sin(1+x*math.pi/(span/4))
                     if -0.3 < sine < 0.3:

--- a/firefly/static/js/renderer.js
+++ b/firefly/static/js/renderer.js
@@ -79,7 +79,7 @@ firefly.Renderer.prototype._createSVG = function() {
 		//When this is the case, we draw a short "line" 0.2 px to the side of the original
 		//in order to form a point.  This allows for drawing something like a scatter plot.
 		if (points.length == 1) {
-			points.push([points[0][0] + 0.2, points[0][1]]);
+			points.push([points[0][0] + 0.7, points[0][1]]);
 		} 
 		return points.join("L");
 	}


### PR DESCRIPTION
If a data source passes in only single datapoints with nulls on either side, we _should_ still show these points.  In an effort to Do the Right Thing™, we'll show these points and later make it easier for data source authors to pick their own interpolation if they want.

This is addressing part of an issue brought up in [#34]
