### PR TITLE
Implements listing of saved named dashboards.

### DIFF
--- a/firefly/static/css/firefly.css
+++ b/firefly/static/css/firefly.css
@@ -11,6 +11,8 @@ a:focus, button.pseudo-link:focus, button.pseudo-link::-moz-focus-inner {outline
 .dashboard {width:100%; height:100%;border-spacing:0px; table-layout: fixed;}
 #graphs .graph {vertical-align:top;border:1px solid #222;overflow:hidden;}
 #graphs .graph.empty {vertical-align:middle;text-align:center;background-color:transparent;}
+#graphs .graph.empty a {display:block; margin-top: 2em; margin-bottom: 2em;}
+#graphs .graph.empty hr {width: 8px; background-color: #676767; border: 0; height: 1px; }
 
 .graph .graph-content-container {overflow:hidden; position:relative;}
 #graphs .graph h2 {display:none;}

--- a/firefly/static/css/list_dashboards.css
+++ b/firefly/static/css/list_dashboards.css
@@ -1,0 +1,13 @@
+.dashboard-list .head h1 {
+	font-size: 2em;
+	display: inline;
+}
+
+.dashboard-list .head a {
+	float: right;
+	margin-top: 5px;
+}
+
+.dashboard-list ul li {
+	margin-bottom: 0.5em;
+}

--- a/firefly/static/js/graph.js
+++ b/firefly/static/js/graph.js
@@ -173,10 +173,19 @@ firefly.Graph.prototype.setHeight = function(height) {
 /** set up the cell when transitioning to empty state */
 firefly.Graph.prototype.setDOMAsEmpty = function() {
 	var frag = document.createDocumentFragment();
-	var a = document.createElement('a');
-	a.innerHTML = "add sources";
-	$(a).attr({'rel': 'action-edit-sources', 'href': '#'});
-	frag.appendChild(a);
+
+	var addSourcesLink = document.createElement('a');
+	$(addSourcesLink).text("add sources");
+	$(addSourcesLink).attr({'rel': 'action-edit-sources', 'href': '#'});
+	frag.appendChild(addSourcesLink);
+
+	frag.appendChild(document.createElement('hr'));
+
+	var listDashboardsLink = document.createElement('a');
+	$(listDashboardsLink).text("list dashboards");
+	$(listDashboardsLink).attr({'href': this.makeURL_("dashboards")});
+	frag.appendChild(listDashboardsLink);
+
 	this._legendEl = this._titleEl = this._graphEl = null;
 
 	$(this.container).empty();

--- a/firefly/templates/list_dashboards.html
+++ b/firefly/templates/list_dashboards.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>firefly</title>
+		<link rel="stylesheet" type="text/css" href='{{ static_url("css/reset-min.css") }}'>
+		<style>
+			@font-face {
+				font-family: "Inconsolata";
+				src: url("{{ static_url("fonts/Inconsolata.ttf") }}");
+			}
+		</style>
+		<link href='{{ static_url("css/firefly.css") }}' rel='stylesheet' type='text/css'>
+		<link href='{{ static_url("css/list_dashboards.css") }}' rel='stylesheet' type='text/css'>
+		<link href='{{ static_url("css/chosen.css") }}' rel='stylesheet' type='text/css'>
+	</head>
+	<body>
+		<div class="graphs dashboard-list">
+			<div class="head">
+				<h1>Available Dashboards</h1>
+				<a href="{{url_path_prefix}}">Back to the graphs →</a>
+			</div>
+			<ul>
+			{% for name in names %}
+				<li>
+					<a href="{{url_path_prefix}}named/{{name}}">{{name}}</a>
+				</li>
+			{% end %}
+			</ul>
+		</div>
+	</body>
+</html>

--- a/firefly/ui_server.py
+++ b/firefly/ui_server.py
@@ -124,6 +124,29 @@ class NameHandler(tornado.web.RequestHandler):
         else:
             self.redirect('/')
 
+
+class DashboardListHandler(tornado.web.RequestHandler):
+    """Displays a list of dashboards that have been saved using the
+    functionality in NameHandler.
+    """
+
+    def get(self):
+        conn = self.application.settings['db_connection']
+
+        names = conn.execute("SELECT name FROM names ORDER BY name ASC").fetchall()
+
+        # names comes back in the form of a list of tuples
+        # we only need a list of names, so let's flatten this
+        names = [name[0] for name in names]
+
+        env = {
+            'url_path_prefix': self.application.settings['url_path_prefix'],
+            'names': names
+        }
+
+        self.render("templates/list_dashboards.html", **env)
+
+
 def initialize_ui_server(config, secret_key=None, ioloop=None):
     if not ioloop:
         ioloop = tornado.ioloop.IOLoop.instance()
@@ -148,6 +171,7 @@ def initialize_ui_server(config, secret_key=None, ioloop=None):
         (r"/expand/(.*)", ExpandHandler),
         (r"/redirect/(.*)", RedirectHandler),
         (r"/named/(.*)", NameHandler),
+        (r"/dashboards", DashboardListHandler),
         (r"/static/(.*)", tornado.web.StaticFileHandler, {"path": config['static_path']}),
     ], **config)
 


### PR DESCRIPTION
Implements a new handler, `/dashboards`, which lists all of the named dashboards
that are saved. Also adds a link on the starting graph area which links to the
listing. Closes #33.

Took a few screenshots, but I removed my test data so you only get the barebones.

![Starting screen](http://i.imgur.com/HoK33.png)
![Dashboard list](http://i.imgur.com/a6aVx.png)
