### PR TITLE
add copy/paste graph options

### DIFF
--- a/firefly/static/js/graph.js
+++ b/firefly/static/js/graph.js
@@ -64,6 +64,12 @@ firefly.Graph.prototype.sync = function(serialized) {
 	}
 };
 
+/** sync this graph's options to the serialized representation passed in */
+firefly.Graph.prototype.syncOptions = function(serialized) {
+	this._options = serialized;
+	this.updateGraph();
+};
+
 
 firefly.Graph.prototype.clear = function() {
 	this.sync({});


### PR DESCRIPTION
rearranges graph options to be a little more sensical ("make zoom global" belongs with the graph-specific options, I would argue), and adds the ability to copy/paste just the options for a graph
