### PR TITLE
Do not autoencode ui_server templates.

### DIFF
--- a/firefly/ui_server.py
+++ b/firefly/ui_server.py
@@ -79,6 +79,7 @@ def initialize_ui_server(config, secret_key=None, ioloop=None):
     config["db_connection"] = conn
     config["static_url_prefix"] = os.path.join(config["url_path_prefix"], "static") + "/"
     config["secret_key"] = secret_key
+    config["autoescape"] = None
 
     # init the application instance
     application = tornado.web.Application([


### PR DESCRIPTION
After 2.0.0 tornado uses xhtml_escape to "autoescape" the template. It breaks the json encoded parameter to firefly.init in index.html.
