### PR TITLE
Fix tests after ds enumeration fix

### DIFF
--- a/tests/data_sources/aggregating_data_source_test.py
+++ b/tests/data_sources/aggregating_data_source_test.py
@@ -578,9 +578,9 @@ class AggregatingDataSourceTest(T.TestCase):
 
 		def fake_paths_from_ds(data_source, path):
 			if data_source == expected_data_source:
-				return test_key
+				return [{"name": test_key},]
 			else:
-				return 'src.not_our_key'
+				return [{"name": "src.not_our_key"},]
 
 		with mock.patch.object(self.data_source, '_request_paths_from_ds', fake_paths_from_ds):
 			actual_ds = self.data_source._find_data_source_for_stat_key(test_key)


### PR DESCRIPTION
This makes the mocks actually represent the data format we're using rather than just strings.

After these changes all tests pass.
