### PR TITLE
Limit annotations to 300 so that browsers don't die when viewing long zooms

### DIFF
--- a/firefly/data_server.py
+++ b/firefly/data_server.py
@@ -30,6 +30,10 @@ log = logging.getLogger('firefly_data_server')
 
 DEFAULT_DATA_SERVER_PORT = 8890
 
+# The number of annotations to draw before we stop
+# This cut-off exists because browsers are unhappy with a lot of these
+ANNOTATIONS_CUT_OFF = 300
+
 def token_authed(method):
     def new_method(self):
         token = self.get_argument('token')
@@ -155,7 +159,8 @@ class AnnotationsHandler(GraphBaseHandler):
 
         cursor = self.settings["db"].cursor()
 
-        annotations_rows = cursor.execute('SELECT type, description, time, id FROM annotations WHERE time >= ? and time <= ? ORDER BY time DESC LIMIT 50', (params['start'], params['end']))
+        annotations_rows = cursor.execute('SELECT type, description, time, id FROM annotations WHERE time >= ? and time <= ? ORDER BY time DESC LIMIT ?',
+                                          (params['start'], params['end'], ANNOTATIONS_CUT_OFF))
 
         self.set_header('Content-Type', 'application/json')
         self.set_header("Cache-Control", "no-cache, must-revalidate")


### PR DESCRIPTION
This is a quick change to how we get annotations.  It limits the results to 300 so that browsers don't completely die when viewing a whole year with annotations turned on.

300 was chosen after a few different tries with different values. It seems to be a good mix between performance and allowing a decent number of annotations to be shown.
