### PR TITLE
testing mode needs this.

### DIFF
--- a/firefly/main.py
+++ b/firefly/main.py
@@ -154,6 +154,7 @@ Runs in test mode:
     # setup logging in a configurable manner
     if options.loggingconf:
         config["loggingconf"] = options.loggingconf
+    util.setup_logging(config)
 
     if options.config_file is None:
         config["config_file"] = "firefly.yaml"


### PR DESCRIPTION
Mistakenly removed this in previous fix. Add it back. This is required in testing mode (--testing).

Test runs:
1. make test
2. runs on dev: all look fine
 2-a. with --testing & --loggingconf
 2-b. with --testing but without --loggingconf
 2-c. without --testing but with --loggingconf
 2-d. without --testing & --loggingconf
