### PR TITLE
remove dev-only packages from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,6 @@ requirements = [
     "pycurl",
     "pyyaml == 3.10",
     "tornado >= 1.1, <2.0",
-    "testify == 0.5.2",
-    "PyHamcrest == 1.8",
 ]
 
 


### PR DESCRIPTION
These two packages are for testing only; they are in requirements-dev.txt. They don't need to be in setup.py.
