### PR TITLE
Mitigate timing attack by removing byte-to-byte comparison

### DIFF
--- a/firefly/util.py
+++ b/firefly/util.py
@@ -54,7 +54,7 @@ def verify_access_token(token, key):
     t = token[:15]
     signature = token[15:]
     expected_signature = hmac.new(key, msg=t, digestmod=hashlib.sha1).hexdigest()
-    return signature == expected_signature and int(t) >= int(time.time())
+    return hmac.compare_digest(signature, expected_signature) and int(t) >= int(time.time())
 
 def generate_access_token(key, duration=60):
     """Generate an access token valid for the given number of seconds"""

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py
+envlist = py27
 
 [testenv]
 deps = -rrequirements-dev.txt
 
-[testenv:py]
+[testenv:py27]
 deps = {[testenv]deps}
 commands =
 	testify {posargs:tests}
@@ -21,7 +21,7 @@ commands =
 	pylint --rcfile=.pylintrc tests
 
 [testenv:cover]
-deps = {[testenv:py]deps}
+deps = {[testenv:py27]deps}
     coverage
 commands =
 	coverage erase
@@ -30,7 +30,7 @@ commands =
 	coverage report --omit=.tox/*,tests/*,/usr/share/pyshared/*,/usr/lib/pymodules/* -m
 
 [testenv:docs]
-deps = {[testenv:py]deps}
+deps = {[testenv:py27]deps}
 	sphinx
 changedir = docs
 commands = sphinx-build -b html -d build/doctrees . build/html


### PR DESCRIPTION
Per report from https://hackerone.com/reports/240958 (sorry the link is private to yelp internal), byte-to-byte comparison against access token can lead to attackers guessing the length of the correct parts of the token by measuring the run time of the function.

[hmac.compare_digest()](https://docs.python.org/2.7/library/hmac.html#hmac.compare_digest) is recommended for this issue.